### PR TITLE
glitch in removal of doubly-linked-list node

### DIFF
--- a/src/lru-cache.coffee
+++ b/src/lru-cache.coffee
@@ -6,7 +6,7 @@ class DoubleLinkedList
 
   remove: (node) ->
     if node.pre
-      node.pre = node.next
+      node.pre.next = node.next
     else
       @headNode = node.next
 


### PR DESCRIPTION
when removing a node from the doubly-linked list, the "previous" node's "next" wasn't made to point to the removed element's "next".

:santa: 
